### PR TITLE
Better handling of different possible sizes in the `sample` and `predict` methods of linear regressors

### DIFF
--- a/bayesianbandits/_estimators.py
+++ b/bayesianbandits/_estimators.py
@@ -595,9 +595,12 @@ class NormalRegressor(BaseEstimator, RegressorMixin):
             multivariate_normal.rvs, size=size, random_state=self.random_state_
         )
 
-        samples = np.atleast_2d(rv_gen(self.coef_, cov))  # type: ignore
+        samples = np.atleast_1d(rv_gen(self.coef_, cov))  # type: ignore
 
-        return np.einsum("ij,...j", X, samples)  # type: ignore
+        if self.n_features_ == 1:
+            samples = np.expand_dims(samples, -1)
+
+        return np.atleast_2d(samples @ X.T)  # type: ignore
 
     def decay(self, X: NDArray[Any]) -> None:
         """
@@ -812,9 +815,11 @@ class NormalInverseGammaRegressor(NormalRegressor):
         df = 2 * self.a_
         rv_gen = partial(multivariate_t.rvs, size=size, random_state=self.random_state_)
 
-        samples = np.atleast_2d(rv_gen(self.coef_, shape, df))  # type: ignore
+        samples = np.atleast_1d(rv_gen(self.coef_, shape, df))  # type: ignore
+        if self.n_features_ == 1:
+            samples = np.expand_dims(samples, -1)
 
-        return np.einsum("ij,...j", X, samples)  # type: ignore
+        return np.atleast_2d(samples @ X.T)  # type: ignore
 
     def decay(self, X: NDArray[Any]):
         """

--- a/docs/notebooks/linear-bandits.ipynb
+++ b/docs/notebooks/linear-bandits.ipynb
@@ -226,7 +226,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x7fdbaf5d8ac0>"
+       "<matplotlib.legend.Legend at 0x7eff2f3499a0>"
       ]
      },
      "execution_count": 6,
@@ -350,7 +350,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x7fdba9db1f70>"
+       "<matplotlib.legend.Legend at 0x7eff29b25070>"
       ]
      },
      "execution_count": 9,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bayesianbandits"
-version = "0.2.3"
+version = "0.2.4"
 description = ""
 authors = ["Rishi Kulkarni <rishi@kulkarni.science>"]
 readme = "README.md"

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -1,3 +1,4 @@
+from typing import Literal
 import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal
@@ -530,6 +531,49 @@ def test_normal_regressor_decay(
     assert_almost_equal(clf.predict(X), pre_decay)
 
 
+@pytest.mark.parametrize("obs", [1, 2, 3, 4])
+@pytest.mark.parametrize("covariates", [1, 2, 3, 4])
+def test_normal_regressor_predict_covariates(
+    obs: Literal[1, 2, 3, 4], covariates: Literal[1, 2, 3, 4]
+):
+    """Test NormalRegressor predict with covariates."""
+
+    X = np.random.rand(obs, covariates)
+    y = np.random.rand(obs)
+
+    clf = NormalRegressor(alpha=1, beta=1, random_state=0)
+    clf.fit(X, y)
+
+    pred = clf.predict(X)
+
+    assert pred.shape == (obs,)
+
+    single_pred = clf.predict(X[[0]])
+    assert single_pred.shape == (1,)
+
+
+@pytest.mark.parametrize("obs", [1, 2, 3, 4])
+@pytest.mark.parametrize("covariates", [1, 2, 3, 4])
+@pytest.mark.parametrize("size", [1, 2, 3, 4])
+def test_normal_regressor_sample_covariates(
+    obs: Literal[1, 2, 3, 4], covariates: Literal[1, 2, 3, 4], size: Literal[1, 2, 3, 4]
+):
+    """Test NormalRegressor predict with covariates."""
+
+    X = np.random.rand(obs, covariates)
+    y = np.random.rand(obs)
+
+    clf = NormalRegressor(alpha=1, beta=1, random_state=0)
+    clf.fit(X, y)
+
+    pred = clf.sample(X, size=size)
+
+    assert pred.shape == (size, obs)
+
+    single_pred = clf.sample(X[[0]], size=size)
+    assert single_pred.shape == (size, 1)
+
+
 def test_normal_inverse_gamma_regressor_fit(
     X: NDArray[np.int_],
     y: NDArray[np.int_],
@@ -702,3 +746,46 @@ def test_normal_inverse_gamma_regressor_decay(
     clf.decay(X)
 
     assert_almost_equal(clf.predict(X), pre_decay)
+
+
+@pytest.mark.parametrize("obs", [1, 2, 3, 4])
+@pytest.mark.parametrize("covariates", [1, 2, 3, 4])
+def test_normal_inverse_gamma_regressor_predict_covariates(
+    obs: Literal[1, 2, 3, 4], covariates: Literal[1, 2, 3, 4]
+):
+    """Test NormalRegressor predict with covariates."""
+
+    X = np.random.rand(obs, covariates)
+    y = np.random.rand(obs)
+
+    clf = NormalInverseGammaRegressor()
+    clf.fit(X, y)
+
+    pred = clf.predict(X)
+
+    assert pred.shape == (obs,)
+
+    single_pred = clf.predict(X[[0]])
+    assert single_pred.shape == (1,)
+
+
+@pytest.mark.parametrize("obs", [1, 2, 3, 4])
+@pytest.mark.parametrize("covariates", [1, 2, 3, 4])
+@pytest.mark.parametrize("size", [1, 2, 3, 4])
+def test_normal_inverse_gamma_regressor_sample_covariates(
+    obs: Literal[1, 2, 3, 4], covariates: Literal[1, 2, 3, 4], size: Literal[1, 2, 3, 4]
+):
+    """Test NormalRegressor predict with covariates."""
+
+    X = np.random.rand(obs, covariates)
+    y = np.random.rand(obs)
+
+    clf = NormalInverseGammaRegressor()
+    clf.fit(X, y)
+
+    pred = clf.sample(X, size=size)
+
+    assert pred.shape == (size, obs)
+
+    single_pred = clf.sample(X[[0]], size=size)
+    assert single_pred.shape == (size, 1)


### PR DESCRIPTION
`scipy` `rvs` functions squeeze output arrays and can result in errors when either dimension of X is 1 in `sample`. Similar issue is possible in `predict`. This PR explicitly fixes dimensions with `expand_dims` and adds tests to make sure this is caught easily in the future. 

It also results in a mild performance boost, as `einsum` can be slow. 