### PR TITLE
FIX: Two bugs with new arm initialization

### DIFF
--- a/tests/test_bandit_pickling.py
+++ b/tests/test_bandit_pickling.py
@@ -82,3 +82,4 @@ def test_new_arm(temp_model_file):
     assert not hasattr(loaded, "arm3")
 
     assert hasattr(loaded, "arm4")
+    assert loaded.arm4.learner.random_state == loaded.arm1.learner.random_state


### PR DESCRIPTION
1. Arms initialized during unpickling now have their RNG set to the same as the other arms
2. Arms can be initialized with different learners (useful when, for example, the user has a prior that one arm will be better than another, etc.)