### PR TITLE
Enhancements and Fixes for Updates when `Arm`s have been dropped

### DIFF
--- a/bayesianbandits/__init__.py
+++ b/bayesianbandits/__init__.py
@@ -88,12 +88,19 @@ These are custom exceptions raised by the bandit classes.
     :toctree: _autosummary
 
     DelayedRewardException
+    DelayedRewardWarning
 
 """
 
 
 from ._arm import Arm
-from ._basebandit import Bandit, DelayedRewardException, contextual, restless
+from ._basebandit import (
+    Bandit,
+    DelayedRewardException,
+    DelayedRewardWarning,
+    contextual,
+    restless,
+)
 from ._estimators import (
     DirichletClassifier,
     GammaRegressor,

--- a/bayesianbandits/_basebandit.py
+++ b/bayesianbandits/_basebandit.py
@@ -687,7 +687,7 @@ def restless(
 
     setattr(cls, "update", _restless_update)
 
-    return cast(Type[_B], cls)
+    return cls
 
 
 def check_is_bandit(cls: type):

--- a/bayesianbandits/_basebandit.py
+++ b/bayesianbandits/_basebandit.py
@@ -322,12 +322,23 @@ class Bandit:
                 )
 
             try:
-                arm_to_update = self.arms[self.cache.pop(unique_id)]  # type: ignore
+                assert self.cache is not None  # this is here for the type checker
+                arm = self.cache.pop(unique_id)
             except KeyError:
                 raise DelayedRewardException(
                     f"The unique_id {unique_id} is not in the cache. "
                     "Please use a valid unique identifier."
                 )
+            try:
+                arm_to_update = self.arms[arm]
+            except KeyError:
+                warn(
+                    DelayedRewardWarning(
+                        f"The arm {arm} is not in the bandit. Skipping."
+                    ),
+                    stacklevel=2,
+                )
+                return
 
         else:
             arm_to_update = cast(ArmProtocol, self.last_arm_pulled)
@@ -374,7 +385,17 @@ class Bandit:
             by=arm_names[present_ids],
         ):
             arm_name = arms[0]
-            self.arms[arm_name].update(X_part, y_part)
+            try:
+                arm_to_update = self.arms[arm_name]
+            except KeyError:
+                warn(
+                    DelayedRewardWarning(
+                        f"The arm {arm_name} is not in the bandit. Skipping."
+                    ),
+                    stacklevel=2,
+                )
+                continue
+            arm_to_update.update(X_part, y_part)
 
     @overload
     def sample(self, X: ArrayLike, /, *, size: int = 1) -> ArrayLike:

--- a/docs/notebooks/persistence.ipynb
+++ b/docs/notebooks/persistence.ipynb
@@ -261,6 +261,46 @@
     "print(f\"Learned alpha and beta for arm 3: {loaded_with_removed_arm.arm3.learner.coef_[1]}\")\n",
     "\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When the agent has `delayed_reward` enabled, trying to update with a `unique_id` that corresponds to an arm that no longer exists will emit a `DelayedRewardWarning` and removes the `unique_id` from the cache without updating the bandit. Note that this is also a destructive operation. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_15131/456411773.py:16: DelayedRewardWarning: The arm arm1 is not in the bandit. Skipping.\n",
+      "  loaded_with_new_def.update(1, unique_id=1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "class DelayedAgent(Bandit, learner=est, policy=policy, delayed_reward=True):\n",
+    "    arm1 = Arm(\"Action 1\", reward_func)\n",
+    "    arm2 = Arm(\"Action 2\", reward_func)\n",
+    "\n",
+    "agent = DelayedAgent(rng=1)\n",
+    "agent.pull(unique_id=1)\n",
+    "\n",
+    "joblib.dump(agent, \"agent.pkl\")\n",
+    "\n",
+    "class DelayedAgent(Bandit, learner=est, policy=policy, delayed_reward=True):\n",
+    "    arm2 = Arm(\"Action 2\", reward_func)\n",
+    "    arm3 = Arm(\"Action 3\", reward_func)\n",
+    "\n",
+    "loaded_with_new_def = joblib.load(\"agent.pkl\")\n",
+    "\n",
+    "loaded_with_new_def.update(1, unique_id=1)"
+   ]
   }
  ],
  "metadata": {

--- a/tests/test_bandit_pickling.py
+++ b/tests/test_bandit_pickling.py
@@ -3,9 +3,18 @@ import tempfile
 import joblib
 from numpy.testing import assert_almost_equal
 import pytest
+from typing import IO
+import numpy as np
+from numpy.typing import NDArray
 
 
-from bayesianbandits import Bandit, Arm, epsilon_greedy, GammaRegressor
+from bayesianbandits import (
+    Bandit,
+    Arm,
+    epsilon_greedy,
+    GammaRegressor,
+    DelayedRewardWarning,
+)
 
 
 @pytest.fixture(scope="module")
@@ -26,7 +35,7 @@ def action3():
     print("action3")
 
 
-def reward_func(x):
+def reward_func(x: NDArray[np.float_]) -> NDArray[np.float_]:
     return x
 
 
@@ -36,7 +45,7 @@ class Agent(Bandit, learner=GammaRegressor(1, 1), policy=epsilon_greedy()):
     arm3 = Arm(action3, reward_func)
 
 
-def test_pickle_and_load(temp_model_file):
+def test_pickle_and_load(temp_model_file: IO[bytes]):
     agent = Agent(rng=1)
 
     agent.pull()
@@ -51,7 +60,7 @@ def test_pickle_and_load(temp_model_file):
     assert_almost_equal(loaded.arm1.learner.coef_[1], agent.arm1.learner.coef_[1])
 
 
-def test_remove_arm(temp_model_file):
+def test_remove_arm(temp_model_file: IO[bytes]):
     global Agent
 
     class Agent(Bandit, learner=GammaRegressor(1, 1), policy=epsilon_greedy()):
@@ -66,7 +75,7 @@ def test_remove_arm(temp_model_file):
     assert not hasattr(loaded, "arm3")
 
 
-def test_new_arm(temp_model_file):
+def test_new_arm(temp_model_file: IO[bytes]):
     global Agent
 
     class Agent(Bandit, learner=GammaRegressor(1, 1), policy=epsilon_greedy()):
@@ -83,3 +92,60 @@ def test_new_arm(temp_model_file):
 
     assert hasattr(loaded, "arm4")
     assert loaded.arm4.learner.random_state == loaded.arm1.learner.random_state
+
+
+class DelayedRewardAgent(
+    Bandit, learner=GammaRegressor(1, 1), policy=epsilon_greedy(), delayed_reward=True
+):
+    arm1 = Arm(action1, reward_func)
+    arm2 = Arm(action2, reward_func)
+    arm3 = Arm(action3, reward_func)
+
+
+def test_removed_arm_update_warning(temp_model_file: IO[bytes]):
+    global DelayedRewardAgent
+
+    agent = DelayedRewardAgent(rng=1)
+    agent.pull(unique_id=1)
+    temp_model_file.seek(0)
+    joblib.dump(agent, temp_model_file)
+
+    class DelayedRewardAgent(
+        Bandit,
+        learner=GammaRegressor(1, 1),
+        policy=epsilon_greedy(),
+        delayed_reward=True,
+    ):
+        arm2 = Arm(action1, reward_func)
+        arm3 = Arm(action2, reward_func)
+
+    temp_model_file.seek(0)
+    loaded = joblib.load(temp_model_file)
+
+    with pytest.warns(DelayedRewardWarning):
+        loaded.update(1, unique_id=1)
+
+
+def test_removed_arm_update_warning_batch():
+    global DelayedRewardAgent
+
+    with tempfile.NamedTemporaryFile() as f:
+        agent = DelayedRewardAgent(rng=1)
+        agent.pull(unique_id=1)
+        agent.pull(unique_id=2)
+        joblib.dump(agent, f)
+
+        class DelayedRewardAgent(
+            Bandit,
+            learner=GammaRegressor(1, 1),
+            policy=epsilon_greedy(),
+            delayed_reward=True,
+        ):
+            arm1 = Arm(action1, reward_func)
+            arm3 = Arm(action2, reward_func)
+
+        f.seek(0)
+        loaded = joblib.load(f)
+
+    with pytest.warns(DelayedRewardWarning):
+        loaded.update([1, 2], unique_id=[1, 2])


### PR DESCRIPTION
Fixes #26 

Details:

Fix: Removed unnecessary type casts in our codebase which led to cleaner and more efficient code. (commit: FIX: remove unnecessary cast)

Feature: The system now emits warnings when attempts are made to update arms that are no longer part of the active set. 
